### PR TITLE
Qualify call to `std::move()` with namespace

### DIFF
--- a/src/region.cpp
+++ b/src/region.cpp
@@ -35,11 +35,11 @@ std::unique_ptr<S2Polygon> S2PolyFromCoordinates(nlohmann::json &coordinates) {
 void Region::AddS2RegionFromGeometry(nlohmann::json &geometry) {
     if (geometry["type"] == "Polygon") {
         auto p = S2PolyFromCoordinates(geometry["coordinates"]);
-        mRegions.push_back(move(p));
+        mRegions.push_back(std::move(p));
     } else if (geometry["type"] == "MultiPolygon") {
         for (auto polygon : geometry["coordinates"]) {
             auto p = S2PolyFromCoordinates(polygon);
-            mRegions.push_back(move(p));
+            mRegions.push_back(std::move(p));
         }
     }
 }


### PR DESCRIPTION
This fixes two compiler warnings emitted by Apple clang version 16.0.0 (clang-1600.0.26.3):

```
/Users/sascha/src/OSMExpress/src/region.cpp:38:28: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
   38 |         mRegions.push_back(move(p));
      |                            ^
      |                            std::
/Users/sascha/src/OSMExpress/src/region.cpp:42:32: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
   42 |             mRegions.push_back(move(p));
      |                                ^
      |                                std::
```