### PR TITLE
Make explicit conversion from timestamp to seconds

### DIFF
--- a/src/update.cpp
+++ b/src/update.cpp
@@ -50,7 +50,7 @@ class DataUpdate : public osmium::handler::Handler {
         setTags<Node::Builder>(node.tags(),nodeMsg);
         auto metadata = nodeMsg.initMetadata();
         metadata.setVersion(node.version());
-        metadata.setTimestamp(node.timestamp());
+        metadata.setTimestamp(node.timestamp().seconds_since_epoch());
         metadata.setChangeset(node.changeset());
         metadata.setUid(node.uid());
         metadata.setUser(node.user());
@@ -104,7 +104,7 @@ class DataUpdate : public osmium::handler::Handler {
       setTags<Way::Builder>(way.tags(),wayMsg);
       auto metadata = wayMsg.initMetadata();
       metadata.setVersion(way.version());
-      metadata.setTimestamp(way.timestamp());
+      metadata.setTimestamp(way.timestamp().seconds_since_epoch());
       metadata.setChangeset(way.changeset());
       metadata.setUid(way.uid());
       metadata.setUser(way.user());
@@ -177,7 +177,7 @@ class DataUpdate : public osmium::handler::Handler {
       }
       auto metadata = relationMsg.initMetadata();
       metadata.setVersion(relation.version());
-      metadata.setTimestamp(relation.timestamp());
+      metadata.setTimestamp(relation.timestamp().seconds_since_epoch());
       metadata.setChangeset(relation.changeset());
       metadata.setUid(relation.uid());
       metadata.setUser(relation.user());


### PR DESCRIPTION
This fixes clang compiler warnings:

```
/home/sascha/src/OSMExpress/src/update.cpp:53:31: warning: 'operator long' is deprecated [-Wdeprecated-declarations]
        metadata.setTimestamp(node.timestamp());
                              ^
/home/sascha/src/OSMExpress/vendor/libosmium/include/osmium/osm/timestamp.hpp:253:9: note: 'operator long' has been explicitly marked deprecated here
        OSMIUM_DEPRECATED constexpr operator time_t() const noexcept { // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
        ^
/home/sascha/src/OSMExpress/vendor/libosmium/include/osmium/util/compatibility.hpp:47:43: note: expanded from macro 'OSMIUM_DEPRECATED'
                                          ^
/home/sascha/src/OSMExpress/src/update.cpp:107:29: warning: 'operator long' is deprecated [-Wdeprecated-declarations]
      metadata.setTimestamp(way.timestamp());
                            ^
/home/sascha/src/OSMExpress/vendor/libosmium/include/osmium/osm/timestamp.hpp:253:9: note: 'operator long' has been explicitly marked deprecated here
        OSMIUM_DEPRECATED constexpr operator time_t() const noexcept { // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
        ^
/home/sascha/src/OSMExpress/vendor/libosmium/include/osmium/util/compatibility.hpp:47:43: note: expanded from macro 'OSMIUM_DEPRECATED'
                                          ^
/home/sascha/src/OSMExpress/src/update.cpp:180:29: warning: 'operator long' is deprecated [-Wdeprecated-declarations]
      metadata.setTimestamp(relation.timestamp());
                            ^
/home/sascha/src/OSMExpress/vendor/libosmium/include/osmium/osm/timestamp.hpp:253:9: note: 'operator long' has been explicitly marked deprecated here
        OSMIUM_DEPRECATED constexpr operator time_t() const noexcept { // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
        ^
/home/sascha/src/OSMExpress/vendor/libosmium/include/osmium/util/compatibility.hpp:47:43: note: expanded from macro 'OSMIUM_DEPRECATED'
```