### PR TITLE
Qualify call to std::move() with namespace

### DIFF
--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -295,7 +295,7 @@ void cmdExtract(int argc, char * argv[]) {
   osmium::io::Writer writer{result["output"].as<string>(), header, osmium::io::overwrite::allow};
   osmium::memory::CallbackBuffer cb;
   cb.set_callback([&](osmium::memory::Buffer&& buffer) {
-    writer(move(buffer));
+    writer(std::move(buffer));
   });
 
   {


### PR DESCRIPTION
Fixes a compiler warning emitted by Apple clang 16.0.0:

```
/Users/sascha/src/OSMExpress/src/extract.cpp:298:12: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
  298 |     writer(move(buffer));
      |            ^
      |            std::
```