### PR TITLE
Make explicit conversion from timestamp to seconds

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -159,7 +159,7 @@ class Handler: public osmium::handler::Handler {
       setTags<Node::Builder>(node.tags(),nodeMsg);
       auto metadata = nodeMsg.initMetadata();
       metadata.setVersion(node.version());
-      metadata.setTimestamp(node.timestamp());
+      metadata.setTimestamp(node.timestamp().seconds_since_epoch());
       metadata.setChangeset(node.changeset());
       metadata.setUid(node.uid());
       metadata.setUser(node.user());
@@ -182,7 +182,7 @@ class Handler: public osmium::handler::Handler {
     setTags<Way::Builder>(way.tags(),wayMsg);
     auto metadata = wayMsg.initMetadata();
     metadata.setVersion(way.version());
-    metadata.setTimestamp(way.timestamp());
+    metadata.setTimestamp(way.timestamp().seconds_since_epoch());
     metadata.setChangeset(way.changeset());
     metadata.setUid(way.uid());
     metadata.setUser(way.user());
@@ -216,7 +216,7 @@ class Handler: public osmium::handler::Handler {
     }
     auto metadata = relationMsg.initMetadata();
     metadata.setVersion(relation.version());
-    metadata.setTimestamp(relation.timestamp());
+    metadata.setTimestamp(relation.timestamp().seconds_since_epoch());
     metadata.setChangeset(relation.changeset());
     metadata.setUid(relation.uid());
     metadata.setUser(relation.user());


### PR DESCRIPTION
After this change, Apple clang version 16.0.0 (clang-1600.0.26.3) emits no more warnings when compiling OSMExpress. There’s still plenty of warnings for the dependencies, but that’s of course unrelated to OSMExpress.

Similar to #52, this change fixes the following compiler warnings:

```
/Users/sascha/src/OSMExpress/src/expand.cpp:162:29: warning: 'operator long' is deprecated [-Wdeprecated-declarations]
  162 |       metadata.setTimestamp(node.timestamp());
      |                             ^
/Users/sascha/src/OSMExpress/vendor/libosmium/include/osmium/osm/timestamp.hpp:253:9: note: 'operator long' has been explicitly marked deprecated here
  253 |         OSMIUM_DEPRECATED constexpr operator time_t() const noexcept { // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
      |         ^
/Users/sascha/src/OSMExpress/vendor/libosmium/include/osmium/util/compatibility.hpp:47:43: note: expanded from macro 'OSMIUM_DEPRECATED'
   47 | # define OSMIUM_DEPRECATED __attribute__((deprecated))
      |                                           ^
/Users/sascha/src/OSMExpress/src/expand.cpp:185:27: warning: 'operator long' is deprecated [-Wdeprecated-declarations]
  185 |     metadata.setTimestamp(way.timestamp());
      |                           ^
/Users/sascha/src/OSMExpress/vendor/libosmium/include/osmium/osm/timestamp.hpp:253:9: note: 'operator long' has been explicitly marked deprecated here
  253 |         OSMIUM_DEPRECATED constexpr operator time_t() const noexcept { // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
      |         ^
/Users/sascha/src/OSMExpress/vendor/libosmium/include/osmium/util/compatibility.hpp:47:43: note: expanded from macro 'OSMIUM_DEPRECATED'
   47 | # define OSMIUM_DEPRECATED __attribute__((deprecated))
      |                                           ^
/Users/sascha/src/OSMExpress/src/expand.cpp:219:27: warning: 'operator long' is deprecated [-Wdeprecated-declarations]
  219 |     metadata.setTimestamp(relation.timestamp());
      |                           ^
/Users/sascha/src/OSMExpress/vendor/libosmium/include/osmium/osm/timestamp.hpp:253:9: note: 'operator long' has been explicitly marked deprecated here
  253 |         OSMIUM_DEPRECATED constexpr operator time_t() const noexcept { // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
      |         ^
/Users/sascha/src/OSMExpress/vendor/libosmium/include/osmium/util/compatibility.hpp:47:43: note: expanded from macro 'OSMIUM_DEPRECATED'
   47 | # define OSMIUM_DEPRECATED __attribute__((deprecated))
      |                                           ^
```