### PR TITLE
Rename CHECK macro to CHECK_LMDB

### DIFF
--- a/examples/bbox_wkt.cpp
+++ b/examples/bbox_wkt.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <iomanip>
 #include "osmx/storage.h"
+#include "osmx/util.h"
 #include "s2/s2latlng.h"
 #include "s2/s2region_coverer.h"
 #include "s2/s2latlng_rect.h"
@@ -20,7 +21,7 @@ int main(int argc, char* argv[]) {
 
   MDB_env* env = osmx::db::createEnv(args[1]);
   MDB_txn* txn;
-  CHECK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+  CHECK_LMDB(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
 
   // Create a S2LatLngRect.
   auto lo = S2LatLng::FromDegrees(stof(args[3]),stof(args[2]));
@@ -44,8 +45,8 @@ int main(int argc, char* argv[]) {
   Roaring64Map node_ids;
   MDB_dbi dbi;
   MDB_cursor *cursor;
-  CHECK(mdb_dbi_open(txn, "cell_node", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-  CHECK(mdb_cursor_open(txn,dbi,&cursor));
+  CHECK_LMDB(mdb_dbi_open(txn, "cell_node", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+  CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
   for (auto cell_id : covering.cell_ids()) {
     osmx::db::traverseCell(cursor,cell_id,node_ids);
   }
@@ -55,8 +56,8 @@ int main(int argc, char* argv[]) {
 
   // Get all way_ids that are referred to by node_ids.
   Roaring64Map way_ids;
-  CHECK(mdb_dbi_open(txn, "node_way", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-  CHECK(mdb_cursor_open(txn,dbi,&cursor));
+  CHECK_LMDB(mdb_dbi_open(txn, "node_way", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+  CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
   for (auto const &node_id : node_ids) {
     osmx::db::traverseReverse(cursor,node_id,way_ids);
   }

--- a/examples/way_wkt.cpp
+++ b/examples/way_wkt.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <iomanip>
 #include "osmx/storage.h"
+#include "osmx/util.h"
 
 using namespace std;
 
@@ -14,7 +15,7 @@ int main(int argc, char* argv[]) {
   // Opening a database: create an Environment, and then a Transaction within the environment. 
   MDB_env* env = osmx::db::createEnv(args[1]);
   MDB_txn* txn;
-  CHECK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+  CHECK_LMDB(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
 
   // Create a Database handle for each element type within the Transaction.
   osmx::db::Locations locations(txn);

--- a/include/osmx/util.h
+++ b/include/osmx/util.h
@@ -1,9 +1,10 @@
 #pragma once
 #include <chrono>
 #include <iostream>
+#include "lmdb.h"
 #include "osmium/tags/taglist.hpp"
 
-#define CHECK(x) if (0 != x) { printf("%s, file %s, line %d.\n", mdb_strerror(x), __FILE__, __LINE__); abort(); }
+#define CHECK_LMDB(x) if (0 != x) { printf("%s, file %s, line %d.\n", mdb_strerror(x), __FILE__, __LINE__); abort(); }
 
 // a higher cell level results in more precise extracts, as the size of 1 cell is the minimum index resolution.
 #define CELL_INDEX_LEVEL 16

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include "osmx/storage.h"
 #include "osmx/cmd.h"
+#include "osmx/util.h"
 
 using namespace std;
 using namespace osmx;
@@ -47,7 +48,7 @@ int main(int argc, char* argv[]) {
     }
     MDB_env* env = db::createEnv(args[2]);
     MDB_txn* txn;
-    CHECK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+    CHECK_LMDB(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
 
     if (args.size() >= 4) {
       if (args[3] == "node") {
@@ -97,9 +98,9 @@ int main(int argc, char* argv[]) {
       auto tables = {"locations","nodes","ways","relations","cell_node","node_way","node_relation","way_relation","relation_relation"};
       for (auto const &table : tables) {
         MDB_dbi dbi;
-        CHECK(mdb_dbi_open(txn, table, MDB_INTEGERKEY, &dbi));
+        CHECK_LMDB(mdb_dbi_open(txn, table, MDB_INTEGERKEY, &dbi));
         MDB_stat stat;
-        CHECK(mdb_stat(txn,dbi,&stat));
+        CHECK_LMDB(mdb_stat(txn,dbi,&stat));
         cout << table << ": " << stat.ms_entries << endl;
       }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -12,6 +12,7 @@
 #include "s2/s2latlng.h"
 #include "s2/s2cell_id.h"
 #include "osmx/storage.h"
+#include "osmx/util.h"
 #include "osmx/messages.capnp.h"
 
 using namespace std;
@@ -138,7 +139,7 @@ class Handler: public osmium::handler::Handler {
   }
 
   ~Handler() {
-    CHECK(mdb_txn_commit(mTxn));
+    CHECK_LMDB(mdb_txn_commit(mTxn));
     mCellNode.writeDb(mEnv);
     mNodeWay.writeDb(mEnv);
     mNodeRelation.writeDb(mEnv);
@@ -268,7 +269,7 @@ void cmdExpand(int argc, char* argv[]) {
   Timer timer("convert");
   MDB_env* env = db::createEnv(output,true);
   MDB_txn* txn;
-  CHECK(mdb_txn_begin(env, NULL, 0, &txn));
+  CHECK_LMDB(mdb_txn_begin(env, NULL, 0, &txn));
 
   const osmium::io::File input_file{input};
   osmium::io::ReaderWithProgressBar reader{true, input_file, osmium::osm_entity_bits::object};

--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -12,6 +12,7 @@
 #include "nlohmann/json.hpp"
 #include "osmx/storage.h"
 #include "osmx/region.h"
+#include "osmx/util.h"
 
 using namespace std;
 using namespace osmx;
@@ -152,7 +153,7 @@ void cmdExtract(int argc, char * argv[]) {
 
   MDB_env* env = db::createEnv(result["osmx"].as<string>(),false);
   MDB_txn* txn;
-  CHECK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+  CHECK_LMDB(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
 
   db::Metadata metadata(txn);
   auto timestamp = metadata.get("osmosis_replication_timestamp");
@@ -165,8 +166,8 @@ void cmdExtract(int argc, char * argv[]) {
     ProgressSection section(prog,prog.cells_total,prog.cells_prog,covering.size(),jsonOutput);
     MDB_dbi dbi;
     MDB_cursor *cursor;
-    CHECK(mdb_dbi_open(txn, "cell_node", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-    CHECK(mdb_cursor_open(txn,dbi,&cursor));
+    CHECK_LMDB(mdb_dbi_open(txn, "cell_node", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+    CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
     for (auto cell_id : covering.cell_ids()) {
       db::traverseCell(cursor,cell_id,node_ids);
       section.tick();
@@ -178,8 +179,8 @@ void cmdExtract(int argc, char * argv[]) {
     ProgressSection section(prog,prog.nodes_total,prog.nodes_prog,node_ids.cardinality(),jsonOutput);
     MDB_dbi dbi;
     MDB_cursor *cursor;
-    CHECK(mdb_dbi_open(txn, "node_way", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-    CHECK(mdb_cursor_open(txn,dbi,&cursor));
+    CHECK_LMDB(mdb_dbi_open(txn, "node_way", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+    CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
     for (auto const &node_id : node_ids) {
       db::traverseReverse(cursor,node_id,way_ids);
       section.tick();
@@ -191,8 +192,8 @@ void cmdExtract(int argc, char * argv[]) {
   {
     MDB_dbi dbi;
     MDB_cursor *cursor;
-    CHECK(mdb_dbi_open(txn, "node_relation", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-    CHECK(mdb_cursor_open(txn,dbi,&cursor));
+    CHECK_LMDB(mdb_dbi_open(txn, "node_relation", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+    CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
     for (auto const &node_id : node_ids) {
       db::traverseReverse(cursor,node_id,relation_ids);
     }
@@ -201,8 +202,8 @@ void cmdExtract(int argc, char * argv[]) {
   {
     MDB_dbi dbi;
     MDB_cursor *cursor;
-    CHECK(mdb_dbi_open(txn, "way_relation", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-    CHECK(mdb_cursor_open(txn,dbi,&cursor));
+    CHECK_LMDB(mdb_dbi_open(txn, "way_relation", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+    CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
     for (auto const &way_id : way_ids) {
       db::traverseReverse(cursor,way_id,relation_ids);
     }
@@ -211,8 +212,8 @@ void cmdExtract(int argc, char * argv[]) {
   {
     MDB_dbi dbi;
     MDB_cursor *cursor;
-    CHECK(mdb_dbi_open(txn, "relation_relation", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
-    CHECK(mdb_cursor_open(txn,dbi,&cursor));
+    CHECK_LMDB(mdb_dbi_open(txn, "relation_relation", MDB_INTEGERKEY | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &dbi));
+    CHECK_LMDB(mdb_cursor_open(txn,dbi,&cursor));
     Roaring64Map discovered_relations;
     Roaring64Map discovered_relations_2;
 

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -1,11 +1,12 @@
 #include "osmx/storage.h"
+#include "osmx/util.h"
 
 namespace osmx { namespace db {
 
 
 MDB_env *createEnv(std::string path, bool writable) {
   MDB_env* env;
-  CHECK(mdb_env_create(&env));
+  CHECK_LMDB(mdb_env_create(&env));
 
   // the maximum size of any LMDB dataset. 
   // 2TB is a safe number for just OSM data as of 02/2023
@@ -14,12 +15,12 @@ MDB_env *createEnv(std::string path, bool writable) {
   mdb_env_set_maxdbs(env,10);
   int flags = 0;
   if (!writable) flags |= MDB_RDONLY;
-  CHECK(mdb_env_open(env, path.c_str(),MDB_NOSUBDIR | MDB_NORDAHEAD | MDB_NOSYNC | flags, 0664));
+  CHECK_LMDB(mdb_env_open(env, path.c_str(),MDB_NOSUBDIR | MDB_NORDAHEAD | MDB_NOSYNC | flags, 0664));
   return env;
 }
 
 Metadata::Metadata(MDB_txn *txn) : mTxn(txn) {
-  CHECK(mdb_dbi_open(mTxn, "metadata", MDB_CREATE, &mDbi));
+  CHECK_LMDB(mdb_dbi_open(mTxn, "metadata", MDB_CREATE, &mDbi));
 }
 
 void Metadata::put(const std::string &key_str, const std::string &value_str) {
@@ -28,7 +29,7 @@ void Metadata::put(const std::string &key_str, const std::string &value_str) {
     key.mv_data = (void *)key_str.data();
     data.mv_size = value_str.size();
     data.mv_data = (void *)value_str.data();
-    CHECK(mdb_put(mTxn,mDbi, &key, &data, 0));
+    CHECK_LMDB(mdb_put(mTxn,mDbi, &key, &data, 0));
 }
 
 std::string Metadata::get(const std::string &key_str) {
@@ -41,7 +42,7 @@ std::string Metadata::get(const std::string &key_str) {
 }
 
 Elements::Elements(MDB_txn *txn, const std::string &name) : mTxn(txn) {
-  CHECK(mdb_dbi_open(txn, name.c_str(), MDB_INTEGERKEY | MDB_CREATE, &mDbi));
+  CHECK_LMDB(mdb_dbi_open(txn, name.c_str(), MDB_INTEGERKEY | MDB_CREATE, &mDbi));
 }
 
 void Elements::put(uint64_t id, kj::VectorOutputStream &vos, int flags) {
@@ -50,7 +51,7 @@ void Elements::put(uint64_t id, kj::VectorOutputStream &vos, int flags) {
   key.mv_data = (void *)&id;
   data.mv_size = vos.getArray().size();
   data.mv_data = (void *)vos.getArray().begin();
-  CHECK(mdb_put(mTxn, mDbi, &key, &data, flags));
+  CHECK_LMDB(mdb_put(mTxn, mDbi, &key, &data, flags));
 }
 
 void Elements::del(uint64_t id) {
@@ -71,13 +72,13 @@ capnp::FlatArrayMessageReader Elements::getReader(uint64_t id) {
   MDB_val key, data;
   key.mv_size = sizeof(uint64_t);
   key.mv_data = (void *)&id;
-  CHECK(mdb_get(mTxn,mDbi,&key,&data));
+  CHECK_LMDB(mdb_get(mTxn,mDbi,&key,&data));
   auto arr = kj::ArrayPtr<const capnp::word>((const capnp::word *)data.mv_data,data.mv_size);
   return capnp::FlatArrayMessageReader(arr);
 }
 
 Locations::Locations(MDB_txn *txn) : mTxn(txn) {
-    CHECK(mdb_dbi_open(mTxn, "locations", MDB_INTEGERKEY | MDB_CREATE, &mDbi));
+    CHECK_LMDB(mdb_dbi_open(mTxn, "locations", MDB_INTEGERKEY | MDB_CREATE, &mDbi));
 }
 
 void Locations::put(uint64_t id, const Location value, int flags) {
@@ -92,7 +93,7 @@ void Locations::put(uint64_t id, const Location value, int flags) {
 
   data.mv_size = sizeof(uint32_t) * 3;
   data.mv_data = (void *)&buf;
-  CHECK(mdb_put(mTxn, mDbi, &key, &data, flags));
+  CHECK_LMDB(mdb_put(mTxn, mDbi, &key, &data, flags));
 }
 
 void Locations::del(uint64_t id) {
@@ -108,7 +109,7 @@ Location Locations::get(uint64_t id) const {
   key.mv_data = (void *)&id;
   int retval = mdb_get(mTxn, mDbi, &key, &data);
   if (retval == MDB_NOTFOUND) return Location{};
-  CHECK(retval);
+  CHECK_LMDB(retval);
   int32_t *buf = (int32_t *)data.mv_data;
   return Location{osmium::Location(buf[0],buf[1]),buf[2]};
 }
@@ -122,7 +123,7 @@ bool Locations::exists(uint64_t id) {
 }
 
 Index::Index(MDB_txn *txn, const std::string &name) : mTxn(txn) {
-  CHECK(mdb_dbi_open(txn, name.c_str(), MDB_INTEGERKEY | MDB_CREATE | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &mDbi));
+  CHECK_LMDB(mdb_dbi_open(txn, name.c_str(), MDB_INTEGERKEY | MDB_CREATE | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &mDbi));
 }
 
 void Index::put(uint64_t from, uint64_t osm_id, int flags) {
@@ -131,7 +132,7 @@ void Index::put(uint64_t from, uint64_t osm_id, int flags) {
   key.mv_data = (void *)&from;
   data.mv_size = sizeof(uint64_t);
   data.mv_data = (void *)&osm_id;
-  CHECK(mdb_put(mTxn,mDbi,&key,&data,flags));
+  CHECK_LMDB(mdb_put(mTxn,mDbi,&key,&data,flags));
 }
 
 void Index::del(uint64_t from, uint64_t osm_id ) {
@@ -144,8 +145,8 @@ void Index::del(uint64_t from, uint64_t osm_id ) {
 }
 
 IndexWriter::IndexWriter(MDB_env *env, const std::string &name) : mEnv(env), mName(name) {
-  CHECK(mdb_txn_begin(env, NULL, 0, &mTxn));
-  CHECK(mdb_dbi_open(mTxn, name.c_str(), MDB_INTEGERKEY | MDB_CREATE | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &mDbi));
+  CHECK_LMDB(mdb_txn_begin(env, NULL, 0, &mTxn));
+  CHECK_LMDB(mdb_dbi_open(mTxn, name.c_str(), MDB_INTEGERKEY | MDB_CREATE | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &mDbi));
 }
 
 void IndexWriter::put(uint64_t from, uint64_t osm_id, int flags) {
@@ -154,17 +155,17 @@ void IndexWriter::put(uint64_t from, uint64_t osm_id, int flags) {
   key.mv_data = (void *)&from;
   data.mv_size = sizeof(uint64_t);
   data.mv_data = (void *)&osm_id;
-  CHECK(mdb_put(mTxn,mDbi,&key,&data,flags));
+  CHECK_LMDB(mdb_put(mTxn,mDbi,&key,&data,flags));
   if (mWrites++ == 8000000) {
-    CHECK(mdb_txn_commit(mTxn));
-    CHECK(mdb_txn_begin(mEnv, NULL, 0, &mTxn));
-    CHECK(mdb_dbi_open(mTxn, mName.c_str(), MDB_INTEGERKEY | MDB_CREATE | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &mDbi));
+    CHECK_LMDB(mdb_txn_commit(mTxn));
+    CHECK_LMDB(mdb_txn_begin(mEnv, NULL, 0, &mTxn));
+    CHECK_LMDB(mdb_dbi_open(mTxn, mName.c_str(), MDB_INTEGERKEY | MDB_CREATE | MDB_DUPSORT | MDB_DUPFIXED | MDB_INTEGERDUP, &mDbi));
     mWrites = 0;
   }
 }
 
 void IndexWriter::commit() {
-  CHECK(mdb_txn_commit(mTxn));
+  CHECK_LMDB(mdb_txn_commit(mTxn));
 }
 
 void traverseCell(MDB_cursor *cursor,S2CellId cell_id,Roaring64Map &set) {

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -10,6 +10,7 @@
 #include "s2/s2latlng.h"
 #include "s2/s2cell_union.h"
 #include "osmx/storage.h"
+#include "osmx/util.h"
 
 using namespace std;
 using namespace osmx;
@@ -259,7 +260,7 @@ void cmdUpdate(int argc, char* argv[]) {
 
   MDB_env* env = db::createEnv(osmx,true);
   MDB_txn* txn;
-  CHECK(mdb_txn_begin(env, NULL, 0, &txn));
+  CHECK_LMDB(mdb_txn_begin(env, NULL, 0, &txn));
 
   string old_seqnum = "UNKNOWN";
   auto new_seqnum = result["seqnum"].as<string>();
@@ -282,7 +283,7 @@ void cmdUpdate(int argc, char* argv[]) {
       metadata.put("osmosis_replication_sequence_number",new_seqnum);
       metadata.put("osmosis_replication_timestamp",new_timestamp);
     }
-    CHECK(mdb_txn_commit(txn));
+    CHECK_LMDB(mdb_txn_commit(txn));
     cout << "Committed: ";
   } else {
     mdb_txn_abort(txn);


### PR DESCRIPTION
A macro `CHECK()` is also defined by Abseil, whose definitions get included by current releases of the S2 geometry library. The Abseil version of `CHECK()` does not test for LMDB errors.