### PR TITLE
Set up GitHub Dependabot for keeping dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
With this configuration in place, GitHub will automatically send pull requests for upgrading the Alpine Linux version in Dockerfiles when a new version has become available upstream. The pull requests will look like
[this example](https://github.com/brawer/dependabot-docker-test/pull/1).

At the moment, Dependabot does not yet support CMake (or any other build system for C/C++), so it will not try to upgrade the dependent libraries in `CMakeLists.txt`. Maybe I'll implement this, it does not actually look too hard. But no promises.