### PR TITLE
Restrict permissions when running Continuous Integration pipelines

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -11,6 +11,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Addresses a [security warning](https://github.com/bdon/OSMExpress/security/code-scanning/1) found by [CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql).